### PR TITLE
chore(repo): expand gitignore for Python, Flutter, and Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,26 @@
+# macOS
 .DS_Store
+
+# VS Code
 .vscode/
+
+# Scratch / personal notes
 prompt.md
+
+# Python
+__pycache__/
+*.py[cod]
+.mypy_cache/
+.venv/
+venv/
+
+# Flutter / Dart
+build/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+*.g.dart
+
+# Node.js (used by markdownlint / cspell tooling)
+node_modules/

--- a/cspell.json
+++ b/cspell.json
@@ -49,6 +49,7 @@
     "MaterialApp",
     "Moodle",
     "MVVM",
+    "mypy",
     "navbar",
     "notifyListeners",
     "Octocat",
@@ -57,6 +58,7 @@
     "optimize",
     "organize",
     "pubspec",
+    "pycache",
     "pumpAndSettle",
     "pumpWidget",
     "recognize",
@@ -89,6 +91,7 @@
     "untoasted",
     "viewmodel",
     "viewmodels",
+    "venv",
     "VoidCallback",
     "WidgetTester",
     "worksheets"


### PR DESCRIPTION
Adds missing ignore patterns:
- Python: `__pycache__/`, `*.pyc`, `.mypy_cache/`, `.venv/`
- Flutter/Dart: `build/`, `.dart_tool/`, `.flutter-plugins`, `.flutter-plugins-dependencies`, `.packages`, `*.g.dart`
- Node.js: `node_modules/`

Also adds `mypy`, `pycache`, and `venv` to cspell allowlist.