### PR TITLE
chore: add terminal rules and marking gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ moodle_private/
 marking_tools/
 .marking_temp/
 marking_reports/
+moodle_submissions/
+
+# Sensitive marking steering (not for students)
+.kiro/steering/marking-workflow.md
 
 # Southsea Cinema coursework templates
 southsea_cinema/

--- a/.kiro/steering/terminal-rules.md
+++ b/.kiro/steering/terminal-rules.md
@@ -1,0 +1,26 @@
+# Terminal Rules
+
+## Banned commands
+
+Never run interactive or long-running commands in the terminal. These block
+execution and freeze the agent session. Examples of banned patterns:
+
+- `flutter run` (use the user's own terminal or provide the command to run)
+- `npm run dev`, `yarn start`, `webpack --watch`
+- Any command with `--watch` or `--interactive` flags
+- `vim`, `nano`, `less`, `more`, or any interactive editor
+- `python -m http.server` or similar persistent servers
+
+If a dev server or long-running process is needed, **tell the user the exact
+command to run in their own terminal**. Do not start it yourself.
+
+## Safe alternatives
+
+- To check if something compiles: `flutter build web` (terminates)
+- To run tests: `flutter test` (terminates)
+- To check lint: `flutter analyze` (terminates)
+- To install deps: `flutter pub get` (terminates)
+
+## Applies to
+
+All agents and sessions working in this repository, without exception.

--- a/cspell.json
+++ b/cspell.json
@@ -40,6 +40,8 @@
     "hairscarf",
     "IconButton",
     "initState",
+    "Kiro",
+    "kiro",
     "localization",
     "localizations",
     "localize",


### PR DESCRIPTION
- Adds .kiro/steering/terminal-rules.md: bans interactive/long-running commands from agent sessions
- Updates .gitignore: adds moodle_submissions/ and marking-workflow.md
- Adds Kiro to cspell dictionary

No student-visible marking tools or criteria are included in this PR.