### PR TITLE
chore: ban inline scripts in terminal rules

### DIFF
--- a/.kiro/steering/terminal-rules.md
+++ b/.kiro/steering/terminal-rules.md
@@ -10,6 +10,8 @@ execution and freeze the agent session. Examples of banned patterns:
 - Any command with `--watch` or `--interactive` flags
 - `vim`, `nano`, `less`, `more`, or any interactive editor
 - `python -m http.server` or similar persistent servers
+- Inline scripts via `python3 -c "..."` or `<<'EOF'` syntax. Write a temp
+  file instead and run it with `python3 /tmp/script.py`
 
 If a dev server or long-running process is needed, **tell the user the exact
 command to run in their own terminal**. Do not start it yourself.


### PR DESCRIPTION
Adds inline Python scripts (python3 -c and heredocs) to the banned commands list in the terminal-rules steering doc. Agents must write temp files instead.