### PR TITLE
chore: keep the sign-off app out of this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ marking_tools/
 marking_reports/
 moodle_submissions/
 
+# Separate nested repo, contains student names/emails. Not part of this repo.
+sign-off-app/
+
 # Sensitive marking steering (not for students)
 .kiro/steering/marking-workflow.md
 


### PR DESCRIPTION
## Summary

Adds `sign-off-app/` to `.gitignore`.

`sign-off-app/` is a separate nested git repository with its own remote. It showed as untracked in this repo, so a `git add -A` from the workspace root would have committed it here as an embedded repo. It also contains `flutter_sign_offs.csv` with student names and email addresses, so that would have published personal data to this public repo.

Ignoring it removes the risk and keeps the two projects separate.

## Changes

- `.gitignore`: ignore `sign-off-app/`

## Testing

- `pre-commit run --all-files` passes (trailing whitespace, end of files, check yaml, large files, markdownlint, cspell)
- `git check-ignore` confirms `sign-off-app/` is now ignored
- `git status` is clean, and no marking or sign-off data is visible to git

No application code is touched.