### PR TITLE
chore: ignore the root AGENTS.md file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ sign-off-app/
 # Sensitive marking steering (not for students)
 .kiro/steering/marking-workflow.md
 
+# Root agent instructions: reference private marking tooling, local only.
+# Root-anchored so .agents/AGENTS.md is unaffected.
+/AGENTS.md
+
 # Southsea Cinema coursework templates
 southsea_cinema/
 southsea_cinema_private/


### PR DESCRIPTION
## Summary

Ignores a root-level `AGENTS.md`.

That file carries local instructions for AI agents about private marking tooling that is not part of this repository. It should never be published here.

The pattern is root-anchored (`/AGENTS.md`) so the existing tracked `.agents/AGENTS.md` is unaffected.

## Changes

- `.gitignore`: ignore `/AGENTS.md`

## Testing

- `git check-ignore /AGENTS.md` matches; `.agents/AGENTS.md` remains tracked
- `pre-commit run --all-files` passes

No application code is touched.